### PR TITLE
Fix - iele contract encoding issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "nightwatch_remote_debugger_parallel": "nightwatch --config nightwatch_debugger.js --env safari,chrome,default",
     "onchange": "onchange build/app.js -- npm-run-all lint",
     "prepublish": "mkdirp build; npm-run-all -ls downloadsolc_root build",
-    "remixd": "./node_modules/remixd/bin/remixd -s ./contracts",
+    "remixd": "./node_modules/remixd/bin/remixd -s ./contracts --remix-ide http://localhost:8080",
     "selenium": "execr --silent selenium-standalone start",
     "selenium-install": "selenium-standalone install",
     "serve": "execr --silent http-server .",

--- a/remix/remix-lib/src/execution/txHelper.js
+++ b/remix/remix-lib/src/execution/txHelper.js
@@ -35,11 +35,7 @@ module.exports = {
           if (x.startsWith('0x')) {
             return x
           } else if (!isNaN(x)) {
-            if (x.startsWith('-')) {
-              return ieleTranslator.encode(x, {type: 'int'})
-            } else {
-              return '0x' + parseInt(x).toString(16)
-            }
+            return ieleTranslator.encode(x, {type: 'int'})
           } else {
             return '0x' + x
           }


### PR DESCRIPTION
For example.

```
contract Outer {
  define @init(){}
  define public @cmpgt(%a, %b) {
    %r = cmp gt %a, %b
    ret %r
  }
```

If user enters argument `10, 200`, then they are encoded as `0x0a, 0xc8`, which is wrong because `0xc8` would be interpreted as negative number. So calling `cmpgt` would return `0x01`, but the correct result should be `0x00`.

This pull request fixes this issue. We encode integer argument as if it is the `int` type in solidity. 
But if the integer argument is hex decimal, then we just leave it as is. 