### PR TITLE
Update - put kevm testnet support back

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "nightwatch_remote_debugger_parallel": "nightwatch --config nightwatch_debugger.js --env safari,chrome,default",
     "onchange": "onchange build/app.js -- npm-run-all lint",
     "prepublish": "mkdirp build; npm-run-all -ls downloadsolc_root build",
-    "remixd": "./node_modules/remixd/bin/remixd -s ./contracts",
+    "remixd": "./node_modules/remixd/bin/remixd -s ./contracts --remix-ide http://localhost:8080",
     "selenium": "execr --silent selenium-standalone start",
     "selenium-install": "selenium-standalone install",
     "serve": "execr --silent http-server .",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "remix-lib": "latest",
     "remix-solidity": "latest",
     "remix-tests": "latest",
-    "remixd": "git+https://github.com/ethereum/remixd.git",
+    "remixd": "git+https://github.com/ethereum/remixd.git#24f3e29b5a3a99c88ce50a735df765d6dcd239f2",
     "request": "^2.83.0",
     "rimraf": "^2.6.1",
     "selenium-standalone": "^6.0.1",
@@ -58,7 +58,6 @@
   "dependencies": {
     "http-server": "0.9.0",
     "keythereum": "^1.0.4",
-    "remixd": "git+https://github.com/ethereum/remixd.git",
     "rlp": "^2.1.0"
   },
   "repository": {

--- a/remix/remix-lib/src/execution/execution-context.js
+++ b/remix/remix-lib/src/execution/execution-context.js
@@ -88,7 +88,11 @@ function ExecutionContext () {
 
   this.init = function (config) {
     this.config = config // @rv: save config to this object scope
-    executionContext = 'custom-rpc-iele-testnet'
+    if (config.get('history/execution-context')) {
+      executionContext = config.get('history/execution-context')
+    } else {
+      executionContext = 'custom-rpc-iele-testnet'
+    }
     return
     /*
     if (config.get('settings/always-use-vm')) {

--- a/remix/remix-lib/src/execution/txFormat.js
+++ b/remix/remix-lib/src/execution/txFormat.js
@@ -206,7 +206,21 @@ module.exports = {
     } else {
       try {
         params = params.replace(/(^|,\s+|,)(\d+)(\s+,|,|$)/g, '$1"$2"$3') // replace non quoted number by quoted number
+        while (true) {
+          const temp = params
+          params = params.replace(/(^|,\s+|,)(\d+)(\s+,|,|$)/g, '$1"$2"$3')
+          if (temp === params) {
+            break
+          }
+        }
         params = params.replace(/(^|,\s+|,)(0[xX][0-9a-fA-F]+)(\s+,|,|$)/g, '$1"$2"$3') // replace non quoted hex string by quoted hex string
+        while (true) {
+          const temp = params
+          params = params.replace(/(^|,\s+|,)(0[xX][0-9a-fA-F]+)(\s+,|,|$)/g, '$1"$2"$3')
+          if (temp === params) {
+            break
+          }
+        }
         funArgs = JSON.parse('[' + params + ']')
       } catch (e) {
         callback('Error encoding arguments: ' + e)

--- a/remix/remix-lib/src/execution/txFormat.js
+++ b/remix/remix-lib/src/execution/txFormat.js
@@ -205,22 +205,8 @@ module.exports = {
       data = Buffer.from(dataHex, 'hex')
     } else {
       try {
-        params = params.replace(/(^|,\s+|,)(\d+)(\s+,|,|$)/g, '$1"$2"$3') // replace non quoted number by quoted number
-        while (true) {
-          const temp = params
-          params = params.replace(/(^|,\s+|,)(\d+)(\s+,|,|$)/g, '$1"$2"$3')
-          if (temp === params) {
-            break
-          }
-        }
-        params = params.replace(/(^|,\s+|,)(0[xX][0-9a-fA-F]+)(\s+,|,|$)/g, '$1"$2"$3') // replace non quoted hex string by quoted hex string
-        while (true) {
-          const temp = params
-          params = params.replace(/(^|,\s+|,)(0[xX][0-9a-fA-F]+)(\s+,|,|$)/g, '$1"$2"$3')
-          if (temp === params) {
-            break
-          }
-        }
+        params = params.replace(/(^|,\s*)(\d+)(?=\s*,|$)/g, '$1"$2"') // replace non quoted number by quoted number
+        params = params.replace(/(^|,\s*)(0[xX][0-9a-fA-F]+)(?=\s*,|$)/g, '$1"$2"') // replace non quoted hex string by quoted hex string
         funArgs = JSON.parse('[' + params + ']')
       } catch (e) {
         callback('Error encoding arguments: ' + e)

--- a/remix/remix-lib/src/execution/txHelper.js
+++ b/remix/remix-lib/src/execution/txHelper.js
@@ -35,11 +35,7 @@ module.exports = {
           if (x.startsWith('0x')) {
             return x
           } else if (!isNaN(x)) {
-            if (x.startsWith('-')) {
-              return ieleTranslator.encode(x, {type: 'int'})
-            } else {
-              return '0x' + parseInt(x).toString(16)
-            }
+            return ieleTranslator.encode(x, {type: 'int'})
           } else {
             return '0x' + x
           }

--- a/remix/remix-lib/src/execution/txHelper.js
+++ b/remix/remix-lib/src/execution/txHelper.js
@@ -31,8 +31,7 @@ module.exports = {
           if (typeof (x) === 'number') {
             x = x.toString(10)
           }
-
-          if (x.startsWith('0x')) {
+          if (x.match(/^0x/i)) {
             return x
           } else if (!isNaN(x)) {
             return ieleTranslator.encode(x, {type: 'int'})

--- a/remix/remix-lib/src/execution/txListener.js
+++ b/remix/remix-lib/src/execution/txListener.js
@@ -60,9 +60,7 @@ class TxListener {
       let output
       if (executionContext.isVM()) {
         output = txResult.result.vm.return
-      } else if (payload.vm === 'ielevm') { // iele vm
-        output = txResult.result
-      } else { // evm
+      } else { // evm or iele vm
         output = txResult.result
       }
 

--- a/remix/remix-lib/src/execution/txListener.js
+++ b/remix/remix-lib/src/execution/txListener.js
@@ -63,7 +63,7 @@ class TxListener {
       } else if (payload.vm === 'ielevm') { // iele vm
         output = txResult.result
       } else { // evm
-        output = ethJSUtil.toBuffer(txResult.result)
+        output = txResult.result
       }
 
       const tx = {
@@ -438,7 +438,7 @@ class TxListener {
               params: this._decodeInputParams(inputData.substring(8), fnabi)
             }
             if (tx.output) {
-              this._resolvedTransactions[tx.hash].decodedOutput = txFormat.decodeResponse(tx.output, fnabi)
+              this._resolvedTransactions[tx.hash].decodedOutput = txFormat.decodeResponse(ethJSUtil.toBuffer(tx.output), fnabi)
             }
             return this._resolvedTransactions[tx.hash]
           }

--- a/remix/remix-solidity/src/compiler/compiler.js
+++ b/remix/remix-solidity/src/compiler/compiler.js
@@ -740,7 +740,7 @@ function Compiler (handleImportCall, getCompilerAPIUrl) {
   }
 
   function truncateVersion (version) {
-    return version.replace(/^(\d+.\d+.\d+)(.*)/, "$1")
+    return version.replace(/^(\d+.\d+.\d+)(.*)/, '$1')
   }
 
   function updateInterface (data) {

--- a/remix/remix-solidity/src/compiler/compiler.js
+++ b/remix/remix-solidity/src/compiler/compiler.js
@@ -740,11 +740,7 @@ function Compiler (handleImportCall, getCompilerAPIUrl) {
   }
 
   function truncateVersion (version) {
-    var tmp = /^(\d+.\d+.\d+)/.exec(version)
-    if (tmp) {
-      return tmp[1]
-    }
-    return version
+    return version.replace(/^(\d+.\d+.\d+)(.*)/, "$1")
   }
 
   function updateInterface (data) {

--- a/remix/remix-solidity/src/compiler/compiler.js
+++ b/remix/remix-solidity/src/compiler/compiler.js
@@ -748,7 +748,6 @@ function Compiler (handleImportCall, getCompilerAPIUrl) {
   }
 
   function updateInterface (data) {
-    console.log("updateInterface")
     txHelper.visitContracts(data.contracts, (contract) => {
       data.contracts[contract.file][contract.name].abi = solcABI.update(truncateVersion(currentVersion), contract.object.abi)
     })

--- a/src/app.js
+++ b/src/app.js
@@ -1039,7 +1039,4 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
       event_label: name
     })
   })
-
-  // @rv: we set compiler as loaded directly since we don't depend on solc-bin.ethereum.org
-  compiler.onInternalCompilerLoaded()
 }

--- a/src/app/tabs/compile-tab.js
+++ b/src/app/tabs/compile-tab.js
@@ -252,7 +252,7 @@ module.exports = class CompileTab {
     if (self.data.allversions && self.data.selectedVersion) self.updateVersionSelector()
     self._view.compileContainer = yo`
       <div class="${css.compileContainer}">
-        <div id="solidity-compiler-version-selector">
+        <div id="solidity-compiler-version-selector" style="display:none;">
           <span>Current version: </span> ${self._view.version}
           ${self._view.versionSelector}
         </div>

--- a/src/app/tabs/compile-tab.js
+++ b/src/app/tabs/compile-tab.js
@@ -1,6 +1,7 @@
 const yo = require('yo-yo')
 const csjs = require('csjs-inject')
-
+const minixhr = require('minixhr')
+const helper = require('../../lib/helper')
 const TreeView = require('../ui/TreeView')
 const modalDialog = require('../ui/modaldialog')
 const copyToClipboard = require('../ui/copy-to-clipboard')
@@ -9,6 +10,8 @@ const styleGuide = require('../ui/styles-guide/theme-chooser')
 const parseContracts = require('../contract/contractParser')
 const publishOnSwarm = require('../contract/publishOnSwarm')
 const executionContext = require('../../execution-context')
+const tooltip = require('../ui/tooltip')
+const QueryParams = require('../../lib/query-params')
 
 const styles = styleGuide.chooser()
 
@@ -28,7 +31,9 @@ module.exports = class CompileTab {
       compileContainer: null,
       errorContainer: null,
       contractNames: null,
-      contractEl: null
+      contractEl: null,
+      versionSelector: null,
+      version: null
     }
     self.data = {
       autoCompile: self._opts.config.get('autoCompile'),
@@ -36,8 +41,19 @@ module.exports = class CompileTab {
       compileTimeout: null,
       contractsDetails: {},
       maxTime: 1000,
-      timeout: 300
+      timeout: 300,
+      allversions: null,
+      selectedVersion: null,
+      baseurl: 'https://solc-bin.ethereum.org/bin'
     }
+    self._components = {
+      queryParams: new QueryParams()
+    }
+    self.fetchAllVersion((allversions, selectedVersion) => {
+      self.data.allversions = allversions
+      self.data.selectedVersion = selectedVersion
+      if (self._view.versionSelector) self.updateVersionSelector()
+    })
     self._events.editor.register('contentChanged', scheduleCompilation)
     self._events.editor.register('sessionSwitched', scheduleCompilation)
     function scheduleCompilation () {
@@ -79,6 +95,7 @@ module.exports = class CompileTab {
       self._view.compileIcon.classList.remove(`${css.spinningIcon}`)
       self._view.compileIcon.setAttribute('title', '')
     })
+    self._events.compiler.register('compilerLoaded', (version) => self.setVersionText(version))
     self._events.compiler.register('compilationFinished', function finish (success, data, source) {
       // console.log('@compile-tab.js compilationFinished: ', success, data, source)
       if (self._view.compileIcon) {
@@ -146,14 +163,77 @@ module.exports = class CompileTab {
         })
       }
       if (compileToIELE) {
+        const solidityCompilerVersionSelector = document.getElementById('solidity-compiler-version-selector')
         if (executionContext.isIeleVM()) {
+          solidityCompilerVersionSelector.style.display = 'none'
           compileToIELE.setAttribute('checked', '')
         } else {
+          solidityCompilerVersionSelector.style.display = 'block'
           compileToIELE.removeAttribute('checked')
         }
       }
     })
   }
+
+  fetchAllVersion (callback) {
+    var self = this
+    minixhr(`${self.data.baseurl}/list.json`, function (json, event) {
+      // @TODO: optimise and cache results to improve app loading times
+      var allversions, selectedVersion
+      if (event.type !== 'error') {
+        try {
+          const data = JSON.parse(json)
+          allversions = data.builds.slice().reverse()
+          selectedVersion = data.releases[data.latestRelease]
+          if (self._components.queryParams.get().version) selectedVersion = self._components.queryParams.get().version
+        } catch (e) {
+          tooltip('Cannot load compiler version list. It might have been blocked by an advertisement blocker. Please try deactivating any of them from this page and reload.')
+        }
+      } else {
+        allversions = [{ path: 'builtin', longVersion: 'latest local version' }]
+        selectedVersion = 'builtin'
+      }
+      callback(allversions, selectedVersion)
+    })
+  }
+
+  updateVersionSelector () {
+    const self = this
+    self._view.versionSelector.innerHTML = ''
+    self._view.versionSelector.appendChild(yo`<option disabled selected>Select new compiler version</option>`)
+    self.data.allversions.forEach(build => self._view.versionSelector.appendChild(yo`<option value=${build.path}>${build.longVersion}</option>`))
+    self._view.versionSelector.removeAttribute('disabled')
+    self._components.queryParams.update({ version: self.data.selectedVersion })
+    var url
+    if (self.data.selectedVersion === 'builtin') {
+      var location = window.document.location
+      location = location.protocol + '//' + location.host + '/' + location.pathname
+      if (location.endsWith('index.html')) location = location.substring(0, location.length - 10)
+      if (!location.endsWith('/')) location += '/'
+      url = location + 'soljson.js'
+    } else {
+      if (self.data.selectedVersion.indexOf('soljson') !== 0 || helper.checkSpecialChars(self.data.selectedVersion)) {
+        return console.log('loading ' + self.data.selectedVersion + ' not allowed')
+      }
+      url = `${self.data.baseurl}/${self.data.selectedVersion}`
+    }
+
+    self._opts.compiler.loadVersion(false, url)
+    self.setVersionText('(loading)')
+  }
+
+  setVersionText (text) {
+    const self = this
+    self.data.version = text
+    if (self._view.version) self._view.version.innerText = text
+  }
+
+  onchangeLoadVersion (event) {
+    const self = this
+    self.data.selectedVersion = self._view.versionSelector.value
+    self.updateVersionSelector()
+  }
+
   render () {
     const self = this
     if (self._view.el) return self._view.el
@@ -164,8 +244,18 @@ module.exports = class CompileTab {
     self._view.compileToIELE = yo`<input class="${css.compileToIELE}" onchange=${updateCompileToIELE} id="compileToIELE" type="checkbox" title="Compile to IELE">`
     if (self.data.autoCompile) self._view.autoCompile.setAttribute('checked', '')
     if (self.data.compileToIELE) self._view.compileToIELE.setAttribute('checked', '')
+    self._view.version = yo`<span id="version"></span>`
+    self._view.versionSelector = yo`
+    <select onchange=${self.onchangeLoadVersion.bind(self)} class="${css.select}" id="versionSelector" disabled>
+      <option disabled selected>Select new compiler version</option>
+    </select>`
+    if (self.data.allversions && self.data.selectedVersion) self.updateVersionSelector()
     self._view.compileContainer = yo`
       <div class="${css.compileContainer}">
+        <div id="solidity-compiler-version-selector">
+          <span>Current version: </span> ${self._view.version}
+          ${self._view.versionSelector}
+        </div>
         <div class="${css.compileButtons}">
           ${self._view.compileButton}
           <div class="${css.settingsContainer}">
@@ -403,6 +493,13 @@ const css = csjs`
   }
   .questionMark:hover {
     color: ${styles.rightPanel.icon_HoverColor_TogglePanel};
+  }
+  .select {
+    font-weight: bold;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    ${styles.rightPanel.settingsTab.dropdown_SelectCompiler}
+    width: 100%;
   }
   .detailsJSON {
     padding: 8px 0;

--- a/src/app/tabs/run-tab.js
+++ b/src/app/tabs/run-tab.js
@@ -809,7 +809,7 @@ function settings (container, appAPI, appEvents, opts) {
       name: 'KEVM Testnet',
       context: 'custom-rpc-kevm-testnet',
       chainId: undefined,
-      rpcUrl: 'https://kevm-testnet.iohkdev.io:8546/',
+      rpcUrl: (window.location.protocol + '//' + window.location.hostname + ':8546/'),
       vm: 'evm'
     })
     // You can click `Connect to Custom RPC` button to connect to custom rpc node to do your development testing.

--- a/src/app/tabs/run-tab.js
+++ b/src/app/tabs/run-tab.js
@@ -804,6 +804,14 @@ function settings (container, appAPI, appEvents, opts) {
       rpcUrl: (window.location.protocol + '//' + window.location.hostname + ':8546/'),
       vm: 'ielevm'
     })
+
+    addIfNotExists({
+      name: 'KEVM Testnet',
+      context: 'custom-rpc-kevm-testnet',
+      chainId: undefined,
+      rpcUrl: 'https://kevm-testnet.iohkdev.io:8546/',
+      vm: 'evm'
+    })
     // You can click `Connect to Custom RPC` button to connect to custom rpc node to do your development testing.
 
     // TODO: remove the `filter` below in the future when IELE testnet launches

--- a/src/universal-dapp.js
+++ b/src/universal-dapp.js
@@ -684,10 +684,6 @@ UniversalDApp.prototype.addCustomRPC = function ({rpcUrl, chainId, vm}) {
   rpcUrl = rpcUrl.trim()
   let name = `${rpcUrl} (chainId: ${chainId})`
   let context = `custom-rpc-${name}`
-  if (rpcUrl.match(/^https:\/\/kevm-testnet\.iohkdev\.io:8546/)) { // kevm testnet
-    name = 'KEVM Testnet'
-    context = `custom-rpc-kevm-testnet`
-  }
   const customRPC = {
     rpcUrl,
     chainId,


### PR DESCRIPTION
This pull request does the following jobs:

* Put KEVM support back. However, I hard coded the KEVM RPC url [here run-tab.js:812](https://github.com/input-output-hk/remix-ide/compare/phase/iele_testnet...input-output-hk:update/put-kevm-testnet-support-back?expand=1#diff-b2d36c7664b525607de0fb789d7a689cR812), which is not very ideal from my point of view. Do you guys have any suggestions?
* I move pull request [#15](https://github.com/input-output-hk/remix-ide/pull/15) to this pull request.
* Move the solidity compiler version selector from `settings-tab.js` to `compile-tab.js` for KEVM environment.

Please help test this pull request.  
Thank you!