### PR TITLE
Fix solidity code interface compilation bug

### DIFF
--- a/remix/remix-solidity/src/compiler/compiler.js
+++ b/remix/remix-solidity/src/compiler/compiler.js
@@ -268,7 +268,7 @@ function Compiler (handleImportCall, getCompilerAPIUrl) {
               bytecode: {
                 object: contract['bin']
               },
-              ieleAssembly: contract['asm']['code']
+              ieleAssembly: contract['asm'] ? contract['asm']['code'] : null
             }
             delete contract['asm']
             delete contract['bin']


### PR DESCRIPTION
For `interface`, the returned `asm` field would be null.
This pr fixed the case.

for example:

```solidity
pragma solidity ^0.4.22;

interface Test {
    function transferOwnership(address addr) external;
}
```